### PR TITLE
테스트: 브로커리지와 태그 서비스 업데이트 분기 검증 추가

### DIFF
--- a/packages/backend/src/brokerage/brokerage.service.spec.ts
+++ b/packages/backend/src/brokerage/brokerage.service.spec.ts
@@ -1,0 +1,61 @@
+import { BrokerageService } from './brokerage.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('BrokerageService', () => {
+  let service: BrokerageService;
+  let prismaMock: {
+    brokerageAccount: {
+      update: jest.Mock;
+    };
+  };
+
+  beforeEach(() => {
+    prismaMock = {
+      brokerageAccount: {
+        update: jest.fn(),
+      },
+    };
+
+    service = new BrokerageService(prismaMock as unknown as PrismaService);
+  });
+
+  it('updateAccount 호출 시 apiKey, apiSecret, description이 undefined이면 Prisma data에 포함되지 않는다', async () => {
+    const updatedAccount = { id: 'account-id' };
+    prismaMock.brokerageAccount.update.mockResolvedValue(updatedAccount);
+
+    const result = await service.updateAccount({
+      id: 'account-id',
+      apiKey: undefined,
+      apiSecret: undefined,
+      description: undefined,
+    });
+
+    expect(prismaMock.brokerageAccount.update).toHaveBeenCalledWith({
+      where: { id: 'account-id' },
+      data: {},
+    });
+    expect(result).toBe(updatedAccount);
+  });
+
+  it('updateAccount 호출 시 apiKey, apiSecret, description이 null이면 Prisma data에 null로 설정된다', async () => {
+    const updatedAccount = { id: 'account-id', apiKey: null, apiSecret: null, description: null };
+    prismaMock.brokerageAccount.update.mockResolvedValue(updatedAccount);
+
+    const result = await service.updateAccount({
+      id: 'account-id',
+      apiKey: null as unknown as string,
+      apiSecret: null as unknown as string,
+      description: null as unknown as string,
+    });
+
+    expect(prismaMock.brokerageAccount.update).toHaveBeenCalledWith({
+      where: { id: 'account-id' },
+      data: {
+        apiKey: null,
+        apiSecret: null,
+        description: null,
+      },
+    });
+    expect(result).toBe(updatedAccount);
+  });
+});

--- a/packages/backend/src/tags/tags.service.spec.ts
+++ b/packages/backend/src/tags/tags.service.spec.ts
@@ -1,0 +1,58 @@
+import { TagsService } from './tags.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('TagsService', () => {
+  let service: TagsService;
+  let prismaMock: {
+    tag: {
+      update: jest.Mock;
+    };
+  };
+
+  beforeEach(() => {
+    prismaMock = {
+      tag: {
+        update: jest.fn(),
+      },
+    };
+
+    service = new TagsService(prismaMock as unknown as PrismaService);
+  });
+
+  it('updateTag 호출 시 color가 제공되면 Prisma data에 color가 포함된다', async () => {
+    const updatedTag = { id: 'tag-id', color: '#abcdef' };
+    prismaMock.tag.update.mockResolvedValue(updatedTag);
+
+    const result = await service.updateTag({
+      id: 'tag-id',
+      color: '#abcdef',
+    });
+
+    expect(prismaMock.tag.update).toHaveBeenCalledWith({
+      where: { id: 'tag-id' },
+      data: {
+        color: '#abcdef',
+      },
+    });
+    expect(result).toBe(updatedTag);
+  });
+
+  it('updateTag 호출 시 color가 undefined이면 Prisma data에서 color가 제외되어 기존 값을 유지한다', async () => {
+    const updatedTag = { id: 'tag-id', name: 'updated' };
+    prismaMock.tag.update.mockResolvedValue(updatedTag);
+
+    const result = await service.updateTag({
+      id: 'tag-id',
+      name: 'updated',
+      color: undefined,
+    });
+
+    expect(prismaMock.tag.update).toHaveBeenCalledWith({
+      where: { id: 'tag-id' },
+      data: {
+        name: 'updated',
+      },
+    });
+    expect(result).toBe(updatedTag);
+  });
+});


### PR DESCRIPTION
## 요약
- BrokerageService.updateAccount의 선택적 인증/설명 필드 처리 분기 테스트를 추가했습니다.
- TagsService.updateTag가 color 값을 갱신하거나 유지하는 시나리오를 검증하는 테스트를 추가했습니다.

## 테스트
- yarn workspace backend test --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ca9c90c7a4832e9b740942d28993ea