### PR TITLE
CI 워크플로에 빌드/린트/테스트 검증 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  quality-checks:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build
+        run: yarn build
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Test
+        run: yarn test


### PR DESCRIPTION
## 요약
- GitHub Actions에 CI 워크플로를 추가해 main 브랜치와 PR에서 실행되도록 구성했습니다.
- Node.js 20 환경에서 의존성을 설치하고 빌드, 린트, 테스트를 순차적으로 수행하도록 했습니다.

## 테스트
- `yarn build` (실패 - 기존 백엔드 TypeScript 오류)
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68cacd3384a8832e89363fecec8d1c4d