### PR TITLE
리밸런싱 그룹 진입 시 분석 비율 즉시 갱신

### DIFF
--- a/packages/frontend/src/components/RebalancingGroupDetailPage.tsx
+++ b/packages/frontend/src/components/RebalancingGroupDetailPage.tsx
@@ -227,6 +227,7 @@ export const RebalancingGroupDetailPage: React.FC<
   } = useGetRebalancingAnalysisQuery({
     variables: { groupId },
     skip: !groupId,
+    fetchPolicy: 'network-only',
   });
 
   const [investmentAmountInput, setInvestmentAmountInput] = useState('1000');
@@ -249,6 +250,7 @@ export const RebalancingGroupDetailPage: React.FC<
       },
     },
     skip: shouldSkipRecommendation,
+    fetchPolicy: 'network-only',
   });
 
   const [setTargetAllocationsMutation, { loading: savingTargets }] =

--- a/packages/frontend/src/components/RebalancingGroupManagementModal.tsx
+++ b/packages/frontend/src/components/RebalancingGroupManagementModal.tsx
@@ -234,6 +234,7 @@ export const RebalancingGroupManagementModal: React.FC<
   } = useGetRebalancingAnalysisQuery({
     variables: { groupId: groupId ?? '' },
     skip: !open || !groupId,
+    fetchPolicy: 'network-only',
   });
 
   const [investmentAmountInput, setInvestmentAmountInput] = useState('1000');
@@ -257,6 +258,7 @@ export const RebalancingGroupManagementModal: React.FC<
       },
     },
     skip: shouldSkipRecommendation,
+    fetchPolicy: 'network-only',
   });
 
   const [setTargetAllocationsMutation, { loading: savingTargets }] =

--- a/packages/frontend/src/components/__tests__/RebalancingGroupDetailPage.test.tsx
+++ b/packages/frontend/src/components/__tests__/RebalancingGroupDetailPage.test.tsx
@@ -255,6 +255,45 @@ describe('RebalancingGroupDetailPage', () => {
     expect(screen.getByText('AAPL, MSFT')).toBeInTheDocument();
   });
 
+  it('분석과 추천 조회는 network-only 정책을 사용한다', () => {
+    setupMocks();
+
+    renderWithProviders(
+      <RebalancingGroupDetailPage groupId="group-1" onClose={vi.fn()} />,
+      { withApollo: false },
+    );
+
+    const analysisCall = mockUseQuery.mock.calls.find(
+      ([document]) => document === GetRebalancingAnalysisDocument,
+    );
+    const recommendationCall = mockUseQuery.mock.calls.find(
+      ([document]) => document === GetInvestmentRecommendationDocument,
+    );
+
+    expect(analysisCall).toBeDefined();
+    expect(analysisCall?.[1]).toEqual(
+      expect.objectContaining({
+        variables: { groupId: 'group-1' },
+        skip: false,
+        fetchPolicy: 'network-only',
+      }),
+    );
+
+    expect(recommendationCall).toBeDefined();
+    expect(recommendationCall?.[1]).toEqual(
+      expect.objectContaining({
+        skip: false,
+        fetchPolicy: 'network-only',
+        variables: {
+          input: {
+            groupId: 'group-1',
+            investmentAmount: 1000,
+          },
+        },
+      }),
+    );
+  });
+
   it('투자 예정 금액 입력을 비워도 빈 값으로 유지한다', async () => {
     setupMocks();
     const user = userEvent.setup();

--- a/packages/frontend/src/components/__tests__/RebalancingGroupManagementModal.test.tsx
+++ b/packages/frontend/src/components/__tests__/RebalancingGroupManagementModal.test.tsx
@@ -152,6 +152,38 @@ describe('RebalancingGroupManagementModal', () => {
     expect((input as HTMLInputElement).value).toBe('');
   });
 
+  it('분석과 추천 조회는 network-only 정책을 사용한다', () => {
+    renderWithProviders(
+      <RebalancingGroupManagementModal
+        open
+        groupId="group-1"
+        onClose={vi.fn()}
+      />,
+      { withApollo: false },
+    );
+
+    expect(mockUseGetRebalancingAnalysisQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: { groupId: 'group-1' },
+        skip: false,
+        fetchPolicy: 'network-only',
+      }),
+    );
+
+    expect(mockUseGetInvestmentRecommendationQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: false,
+        fetchPolicy: 'network-only',
+        variables: {
+          input: {
+            groupId: 'group-1',
+            investmentAmount: 1000,
+          },
+        },
+      }),
+    );
+  });
+
   it('저장 버튼을 클릭하면 그룹 정보와 목표 비율을 저장하고 성공 알림을 표시한다', async () => {
     const onClose = vi.fn();
 


### PR DESCRIPTION
## 요약
- 보유 수량 변경 후 리밸런싱 그룹 관리/상세 진입 시 이전 캐시 비율이 보이는 문제를 수정했습니다.
- 리밸런싱 분석/추천 조회를 캐시 우선이 아닌 네트워크 최신 조회로 고정했습니다.

## 변경 사항
- `RebalancingGroupManagementModal`의 `useGetRebalancingAnalysisQuery`, `useGetInvestmentRecommendationQuery`에 `fetchPolicy: 'network-only'` 적용
- `RebalancingGroupDetailPage`의 `useGetRebalancingAnalysisQuery`, `useGetInvestmentRecommendationQuery`에 `fetchPolicy: 'network-only'` 적용
- 두 컴포넌트 테스트에 `network-only` 정책 호출 검증 케이스 추가

## 실행한 명령
- `pnpm --filter @rebalancing-helper/frontend test -- --run src/components/__tests__/RebalancingGroupManagementModal.test.tsx src/components/__tests__/RebalancingGroupDetailPage.test.tsx`

## 테스트 결과
- 대상 테스트 2개 파일, 16개 테스트 통과

## 관련 이슈/스크린샷
- 관련 이슈: 없음
- UI 변경 없음
